### PR TITLE
Add Perplexity research tools and agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ai-devshop-python
 
-**AI Devshop Python Core**  
-Backend foundation for a next-generation, agent-powered app builder.  
+**AI Devshop Python Core**
+Backend foundation for a next-generation, agent-powered app builder.
 Orchestrates AI research, secure code editing, and workflow automation using OpenAI agents, Perplexity’s research APIs, and a modular tool system.
 
 ## Features (Planned)
@@ -23,8 +23,8 @@ Orchestrates AI research, secure code editing, and workflow automation using Ope
 ```
 
 ## Quick Start (Coming Soon)
-* Clone repo  
-* Install requirements  
+* Clone repo
+* Install requirements
 * Set up `.env` for all keys
 
 ## Roadmap
@@ -35,3 +35,8 @@ Orchestrates AI research, secure code editing, and workflow automation using Ope
 5. Extended support, async, and plugins
 
 **Principles:** Secure, modular, extensible, future-focused.
+
+### New in this version
+- Perplexity integration via `PerplexityAPI`
+- Research tools `quick_search` and `deep_research`
+- `ResearchAgent` using OpenAI `o3` model and Perplexity tools

--- a/agents/__init__.py
+++ b/agents/__init__.py
@@ -1,1 +1,5 @@
 """Agents package."""
+
+from .research_agent import ResearchAgent
+
+__all__ = ["ResearchAgent"]

--- a/agents/research_agent.py
+++ b/agents/research_agent.py
@@ -1,0 +1,16 @@
+"""Agent that leverages Perplexity tools for research."""
+
+from tools import research
+
+
+class ResearchAgent:
+    """Simple agent that exposes research tools."""
+
+    def __init__(self, model: str = "o3") -> None:
+        self.model = model
+
+    def quick_search(self, query: str) -> str:
+        return research.quick_search(query)
+
+    def deep_research(self, query: str, steps: int = 3) -> str:
+        return research.deep_research(query, steps=steps)

--- a/apis/__init__.py
+++ b/apis/__init__.py
@@ -1,1 +1,5 @@
 """APIs package."""
+
+from .perplexity import PerplexityAPI
+
+__all__ = ["PerplexityAPI"]

--- a/apis/perplexity.py
+++ b/apis/perplexity.py
@@ -1,0 +1,27 @@
+import requests
+from config import Config
+
+
+class PerplexityAPI:
+    """Simple wrapper around the Perplexity search API."""
+
+    BASE_URL = "https://api.perplexity.ai/search"
+
+    def __init__(self, api_key: str | None = None) -> None:
+        self.api_key = api_key or Config.get("PERPLEXITY_API_KEY")
+        if not self.api_key:
+            raise ValueError("PERPLEXITY_API_KEY not set")
+
+    def _headers(self) -> dict[str, str]:
+        return {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        }
+
+    def search(self, query: str, depth: int = 1) -> dict:
+        """Perform a search using Perplexity."""
+        payload = {"q": query, "depth": depth}
+        response = requests.post(self.BASE_URL, json=payload, headers=self._headers(), timeout=30)
+        response.raise_for_status()
+        return response.json()

--- a/main.py
+++ b/main.py
@@ -1,11 +1,19 @@
 """Entry point for the ai-devshop-python package."""
 from config import Config
+from agents import ResearchAgent
 
 
 def main() -> None:
-    """Simple startup routine."""
+    """Simple startup routine demonstrating the research agent."""
     greeting = Config.get("AIDEVSHOP_GREETING", "Welcome to AI Devshop!")
     print(greeting)
+
+    agent = ResearchAgent()
+    query = Config.get("AIDEVSHOP_DEMO_QUERY")
+    if query:
+        print("Researching:", query)
+        answer = agent.quick_search(query)
+        print("Answer:", answer)
 
 
 if __name__ == "__main__":

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+openai>=1.3.0
+requests>=2.31.0

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -1,1 +1,5 @@
 """Tools package."""
+
+from .research import quick_search, deep_research
+
+__all__ = ["quick_search", "deep_research"]

--- a/tools/research.py
+++ b/tools/research.py
@@ -1,0 +1,42 @@
+"""Research tools powered by Perplexity."""
+
+from typing import List
+
+import openai
+from config import Config
+from apis.perplexity import PerplexityAPI
+
+
+def quick_search(query: str) -> str:
+    """Return a quick answer from Perplexity."""
+    api = PerplexityAPI()
+    data = api.search(query, depth=1)
+    return data.get("answer", "")
+
+
+def deep_research(query: str, steps: int = 3) -> str:
+    """Perform multi-step research using Perplexity and OpenAI."""
+    api = PerplexityAPI()
+    openai.api_key = Config.get("OPENAI_API_KEY")
+    if not openai.api_key:
+        raise ValueError("OPENAI_API_KEY not set")
+
+    answers: List[str] = []
+    current_query = query
+    for _ in range(steps):
+        result = api.search(current_query, depth=2)
+        text = result.get("answer", "")
+        answers.append(text)
+        followup_prompt = (
+            "Based on the following research answer, suggest a more specific follow-up query to dig deeper.\n" + text
+        )
+        resp = openai.chat.completions.create(
+            model="o3", messages=[{"role": "user", "content": followup_prompt}]
+        )
+        current_query = resp.choices[0].message.content.strip()
+
+    summary_prompt = "\n\n".join(answers) + "\n\nProvide a concise summary of the above research."
+    final_resp = openai.chat.completions.create(
+        model="o3", messages=[{"role": "user", "content": summary_prompt}]
+    )
+    return final_resp.choices[0].message.content.strip()


### PR DESCRIPTION
## Summary
- integrate Perplexity via `PerplexityAPI`
- add `quick_search` and `deep_research` tools using Perplexity and OpenAI o3 model
- provide `ResearchAgent` wrapping these tools
- demonstrate agent in `main.py`
- document new functionality in `README`
- add `requirements.txt` for openai and requests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b6ff615988331b52a9c3238953ee3